### PR TITLE
test: authz grant and feegrant

### DIFF
--- a/starship/__tests__/authz.test.ts
+++ b/starship/__tests__/authz.test.ts
@@ -11,9 +11,9 @@ import { OfflineSigner } from "@cosmjs/proto-signing";
 import { getSigningCosmosClient } from "../../src";
 import { createRPCQueryClient } from "../../src/codegen/cosmos/rpc.query";
 import { assertIsDeliverTxSuccess } from "@cosmjs/stargate";
-import { MessageComposer } from '../../src/codegen/cosmos/authz/v1beta1/tx.registry';
-import { SendAuthorization } from '../../src/codegen/cosmos/bank/v1beta1/authz';
-import { Grant } from '../../src/codegen/cosmos/authz/v1beta1/authz';
+import { MessageComposer } from "../../src/codegen/cosmos/authz/v1beta1/tx.registry";
+import { SendAuthorization } from "../../src/codegen/cosmos/bank/v1beta1/authz";
+import { Grant } from "../../src/codegen/cosmos/authz/v1beta1/authz";
 
 BigInt.prototype["toJSON"] = function () {
   return this.toString();
@@ -67,32 +67,32 @@ describe.each(inits)("$description", ({ description, createWallets }) => {
     await chainData.creditFromFaucet(t2Addr, denom);
   });
 
-  test('authz grant', async () => {
+  test("authz grant", async () => {
     const queryClient = await createRPCQueryClient({ rpcEndpoint });
     const signingClient = await getSigningCosmosClient({
       rpcEndpoint,
       signer: test1Wallet,
     });
 
-
     const msg = MessageComposer.fromPartial.grant({
       grantee: t2Addr,
       granter: t1Addr,
       grant: Grant.fromPartial({
         authorization: SendAuthorization.fromPartial({
-          spendLimit: [ { denom: 'umfx', amount: '10000' } ],
-          allowList: [""] // The list MUST contain a value, otherwise the signed message and the message decoded by the server won't match as the field gets omitted
+          spendLimit: [{ denom: "umfx", amount: "10000" }],
+          allowList: [""], // The list MUST contain a value, otherwise the signed message and the message decoded by the server won't match as the field gets omitted
         }),
-        expiration: null
-      })
-    })
+        expiration: null,
+      }),
+    });
 
     const result = await signingClient.signAndBroadcast(t1Addr, [msg], fee);
     assertIsDeliverTxSuccess(result);
 
-    const grants = await queryClient.cosmos.authz.v1beta1.granterGrants({ granter: t1Addr });
-    expect(grants.grants.length).toBe(1)
-    expect(grants.grants[0].grantee).toBe(t2Addr)
-  })
-})
-
+    const grants = await queryClient.cosmos.authz.v1beta1.granterGrants({
+      granter: t1Addr,
+    });
+    expect(grants.grants.length).toBe(1);
+    expect(grants.grants[0].grantee).toBe(t2Addr);
+  });
+});

--- a/starship/__tests__/authz.test.ts
+++ b/starship/__tests__/authz.test.ts
@@ -1,0 +1,98 @@
+import { ConfigContext, generateMnemonic, useRegistry } from "starshipjs";
+import {
+  checkPoaAdminIs,
+  createAminoWallet,
+  createProtoWallet,
+  initChain,
+  POA_GROUP_ADDRESS,
+} from "../src/test_helper";
+import path from "path";
+import { OfflineSigner } from "@cosmjs/proto-signing";
+import { getSigningCosmosClient } from "../../src";
+import { createRPCQueryClient } from "../../src/codegen/cosmos/rpc.query";
+import { assertIsDeliverTxSuccess } from "@cosmjs/stargate";
+import { MessageComposer } from '../../src/codegen/cosmos/authz/v1beta1/tx.registry';
+import { SendAuthorization } from '../../src/codegen/cosmos/bank/v1beta1/authz';
+import { Grant } from '../../src/codegen/cosmos/authz/v1beta1/authz';
+
+BigInt.prototype["toJSON"] = function () {
+  return this.toString();
+};
+
+const inits = [
+  {
+    description: "authz-module (proto-signing)",
+    createWallets: createProtoWallet,
+  },
+  {
+    description: "authz-module (amino-signing)",
+    createWallets: createAminoWallet,
+  },
+];
+
+// Test Group module endpoints with both proto and amino signing.
+describe.each(inits)("$description", ({ description, createWallets }) => {
+  let test1Wallet: OfflineSigner,
+    test2Wallet: OfflineSigner,
+    t1Addr: string,
+    t2Addr: string,
+    rpcEndpoint: string,
+    fee: { amount: { denom: string; amount: string }[]; gas: string };
+
+  const denom = "umfx";
+
+  beforeAll(async () => {
+    const configFile = path.join(
+      __dirname,
+      "..",
+      "configs",
+      "config.group.local.yaml"
+    );
+    ConfigContext.setConfigFile(configFile);
+    ConfigContext.setRegistry(await useRegistry(configFile));
+
+    const chainData = await initChain("manifest-ledger-beta");
+    rpcEndpoint = chainData.rpcEndpoint;
+
+    await checkPoaAdminIs(rpcEndpoint, POA_GROUP_ADDRESS);
+
+    test1Wallet = await createWallets(generateMnemonic(), chainData.prefix);
+    test2Wallet = await createWallets(generateMnemonic(), chainData.prefix);
+    fee = { amount: [{ denom, amount: "100000" }], gas: "550000" };
+
+    t1Addr = (await test1Wallet.getAccounts())[0].address;
+    t2Addr = (await test2Wallet.getAccounts())[0].address;
+
+    await chainData.creditFromFaucet(t1Addr, denom);
+    await chainData.creditFromFaucet(t2Addr, denom);
+  });
+
+  test('authz grant', async () => {
+    const queryClient = await createRPCQueryClient({ rpcEndpoint });
+    const signingClient = await getSigningCosmosClient({
+      rpcEndpoint,
+      signer: test1Wallet,
+    });
+
+
+    const msg = MessageComposer.fromPartial.grant({
+      grantee: t2Addr,
+      granter: t1Addr,
+      grant: Grant.fromPartial({
+        authorization: SendAuthorization.fromPartial({
+          spendLimit: [ { denom: 'umfx', amount: '10000' } ],
+          allowList: [""] // The list MUST contain a value, otherwise the signed message and the message decoded by the server won't match as the field gets omitted
+        }),
+        expiration: null
+      })
+    })
+
+    const result = await signingClient.signAndBroadcast(t1Addr, [msg], fee);
+    assertIsDeliverTxSuccess(result);
+
+    const grants = await queryClient.cosmos.authz.v1beta1.granterGrants({ granter: t1Addr });
+    expect(grants.grants.length).toBe(1)
+    expect(grants.grants[0].grantee).toBe(t2Addr)
+  })
+})
+

--- a/starship/__tests__/feegrant.test.ts
+++ b/starship/__tests__/feegrant.test.ts
@@ -10,7 +10,6 @@ import path from "path";
 import { OfflineSigner } from "@cosmjs/proto-signing";
 import { getSigningCosmosClient } from "../../src";
 import { createRPCQueryClient } from "../../src/codegen/cosmos/rpc.query";
-import { MsgGrantAllowance } from "../../src/codegen/cosmos/feegrant/v1beta1/tx";
 import {
   AllowedMsgAllowance,
   BasicAllowance,

--- a/starship/__tests__/feegrant.test.ts
+++ b/starship/__tests__/feegrant.test.ts
@@ -1,0 +1,103 @@
+import { ConfigContext, generateMnemonic, useRegistry } from 'starshipjs';
+import {
+  checkPoaAdminIs,
+  createAminoWallet,
+  createProtoWallet,
+  initChain,
+  POA_GROUP_ADDRESS
+} from '../src/test_helper';
+import path from 'path';
+import { OfflineSigner } from '@cosmjs/proto-signing';
+import { getSigningCosmosClient } from '../../src';
+import { createRPCQueryClient } from '../../src/codegen/cosmos/rpc.query';
+import { MsgGrantAllowance } from '../../src/codegen/cosmos/feegrant/v1beta1/tx';
+import { AllowedMsgAllowance, BasicAllowance } from '../../src/codegen/cosmos/feegrant/v1beta1/feegrant';
+import { assertIsDeliverTxSuccess } from '@cosmjs/stargate';
+import { MessageComposer } from '../../src/codegen/cosmos/feegrant/v1beta1/tx.registry';
+
+BigInt.prototype['toJSON'] = function() {
+  return this.toString();
+};
+
+const inits = [
+  {
+    description: 'feegrant-module (proto-signing)',
+    createWallets: createProtoWallet
+  },
+  {
+    description: 'feegrant-module (amino-signing)',
+    createWallets: createAminoWallet
+  }
+];
+
+// Test Group module endpoints with both proto and amino signing.
+describe.each(inits)('$description', ({ description, createWallets }) => {
+  let test1Wallet: OfflineSigner,
+    test2Wallet: OfflineSigner,
+    t1Addr: string,
+    t2Addr: string,
+    rpcEndpoint: string,
+    fee: { amount: { denom: string; amount: string }[]; gas: string };
+
+  const denom = 'umfx';
+
+  beforeAll(async () => {
+    const configFile = path.join(
+      __dirname,
+      '..',
+      'configs',
+      'config.group.local.yaml'
+    );
+    ConfigContext.setConfigFile(configFile);
+    ConfigContext.setRegistry(await useRegistry(configFile));
+
+    const chainData = await initChain('manifest-ledger-beta');
+    rpcEndpoint = chainData.rpcEndpoint;
+
+    await checkPoaAdminIs(rpcEndpoint, POA_GROUP_ADDRESS);
+
+    test1Wallet = await createWallets(generateMnemonic(), chainData.prefix);
+    test2Wallet = await createWallets(generateMnemonic(), chainData.prefix);
+    fee = { amount: [{ denom, amount: '100000' }], gas: '550000' };
+
+    t1Addr = (await test1Wallet.getAccounts())[0].address;
+    t2Addr = (await test2Wallet.getAccounts())[0].address;
+
+    await chainData.creditFromFaucet(t1Addr, denom);
+    await chainData.creditFromFaucet(t2Addr, denom);
+  });
+
+  test('feegrant', async () => {
+    const client = await getSigningCosmosClient({
+      rpcEndpoint,
+      signer: test1Wallet
+    });
+    const queryClient = await createRPCQueryClient({ rpcEndpoint });
+
+
+    const msg = MessageComposer.fromPartial.grantAllowance(
+      {
+        granter: t1Addr,
+        grantee: t2Addr,
+        allowance: AllowedMsgAllowance.fromPartial({
+          allowance: BasicAllowance.fromPartial({
+            spendLimit: [{ denom, amount: '1000000' }],
+            expiration: null
+          }),
+          allowedMessages: ['/cosmos.bank.v1beta1.MsgSend']
+        })
+      }
+    );
+
+    const result = await client.signAndBroadcast(t1Addr, [msg], fee);
+    assertIsDeliverTxSuccess(result);
+    expect(result.code).toEqual(0);
+
+    const allowance = await queryClient.cosmos.feegrant.v1beta1.allowance({
+      granter: t1Addr,
+      grantee: t2Addr
+    });
+    expect(allowance.allowance.granter).toEqual(t1Addr);
+    expect(allowance.allowance.grantee).toEqual(t2Addr);
+  });
+});

--- a/starship/__tests__/feegrant.test.ts
+++ b/starship/__tests__/feegrant.test.ts
@@ -1,37 +1,40 @@
-import { ConfigContext, generateMnemonic, useRegistry } from 'starshipjs';
+import { ConfigContext, generateMnemonic, useRegistry } from "starshipjs";
 import {
   checkPoaAdminIs,
   createAminoWallet,
   createProtoWallet,
   initChain,
-  POA_GROUP_ADDRESS
-} from '../src/test_helper';
-import path from 'path';
-import { OfflineSigner } from '@cosmjs/proto-signing';
-import { getSigningCosmosClient } from '../../src';
-import { createRPCQueryClient } from '../../src/codegen/cosmos/rpc.query';
-import { MsgGrantAllowance } from '../../src/codegen/cosmos/feegrant/v1beta1/tx';
-import { AllowedMsgAllowance, BasicAllowance } from '../../src/codegen/cosmos/feegrant/v1beta1/feegrant';
-import { assertIsDeliverTxSuccess } from '@cosmjs/stargate';
-import { MessageComposer } from '../../src/codegen/cosmos/feegrant/v1beta1/tx.registry';
+  POA_GROUP_ADDRESS,
+} from "../src/test_helper";
+import path from "path";
+import { OfflineSigner } from "@cosmjs/proto-signing";
+import { getSigningCosmosClient } from "../../src";
+import { createRPCQueryClient } from "../../src/codegen/cosmos/rpc.query";
+import { MsgGrantAllowance } from "../../src/codegen/cosmos/feegrant/v1beta1/tx";
+import {
+  AllowedMsgAllowance,
+  BasicAllowance,
+} from "../../src/codegen/cosmos/feegrant/v1beta1/feegrant";
+import { assertIsDeliverTxSuccess } from "@cosmjs/stargate";
+import { MessageComposer } from "../../src/codegen/cosmos/feegrant/v1beta1/tx.registry";
 
-BigInt.prototype['toJSON'] = function() {
+BigInt.prototype["toJSON"] = function () {
   return this.toString();
 };
 
 const inits = [
   {
-    description: 'feegrant-module (proto-signing)',
-    createWallets: createProtoWallet
+    description: "feegrant-module (proto-signing)",
+    createWallets: createProtoWallet,
   },
   {
-    description: 'feegrant-module (amino-signing)',
-    createWallets: createAminoWallet
-  }
+    description: "feegrant-module (amino-signing)",
+    createWallets: createAminoWallet,
+  },
 ];
 
 // Test Group module endpoints with both proto and amino signing.
-describe.each(inits)('$description', ({ description, createWallets }) => {
+describe.each(inits)("$description", ({ description, createWallets }) => {
   let test1Wallet: OfflineSigner,
     test2Wallet: OfflineSigner,
     t1Addr: string,
@@ -39,26 +42,26 @@ describe.each(inits)('$description', ({ description, createWallets }) => {
     rpcEndpoint: string,
     fee: { amount: { denom: string; amount: string }[]; gas: string };
 
-  const denom = 'umfx';
+  const denom = "umfx";
 
   beforeAll(async () => {
     const configFile = path.join(
       __dirname,
-      '..',
-      'configs',
-      'config.group.local.yaml'
+      "..",
+      "configs",
+      "config.group.local.yaml"
     );
     ConfigContext.setConfigFile(configFile);
     ConfigContext.setRegistry(await useRegistry(configFile));
 
-    const chainData = await initChain('manifest-ledger-beta');
+    const chainData = await initChain("manifest-ledger-beta");
     rpcEndpoint = chainData.rpcEndpoint;
 
     await checkPoaAdminIs(rpcEndpoint, POA_GROUP_ADDRESS);
 
     test1Wallet = await createWallets(generateMnemonic(), chainData.prefix);
     test2Wallet = await createWallets(generateMnemonic(), chainData.prefix);
-    fee = { amount: [{ denom, amount: '100000' }], gas: '550000' };
+    fee = { amount: [{ denom, amount: "100000" }], gas: "550000" };
 
     t1Addr = (await test1Wallet.getAccounts())[0].address;
     t2Addr = (await test2Wallet.getAccounts())[0].address;
@@ -67,27 +70,24 @@ describe.each(inits)('$description', ({ description, createWallets }) => {
     await chainData.creditFromFaucet(t2Addr, denom);
   });
 
-  test('feegrant', async () => {
+  test("feegrant", async () => {
     const client = await getSigningCosmosClient({
       rpcEndpoint,
-      signer: test1Wallet
+      signer: test1Wallet,
     });
     const queryClient = await createRPCQueryClient({ rpcEndpoint });
 
-
-    const msg = MessageComposer.fromPartial.grantAllowance(
-      {
-        granter: t1Addr,
-        grantee: t2Addr,
-        allowance: AllowedMsgAllowance.fromPartial({
-          allowance: BasicAllowance.fromPartial({
-            spendLimit: [{ denom, amount: '1000000' }],
-            expiration: null
-          }),
-          allowedMessages: ['/cosmos.bank.v1beta1.MsgSend']
-        })
-      }
-    );
+    const msg = MessageComposer.fromPartial.grantAllowance({
+      granter: t1Addr,
+      grantee: t2Addr,
+      allowance: AllowedMsgAllowance.fromPartial({
+        allowance: BasicAllowance.fromPartial({
+          spendLimit: [{ denom, amount: "1000000" }],
+          expiration: null,
+        }),
+        allowedMessages: ["/cosmos.bank.v1beta1.MsgSend"],
+      }),
+    });
 
     const result = await client.signAndBroadcast(t1Addr, [msg], fee);
     assertIsDeliverTxSuccess(result);
@@ -95,7 +95,7 @@ describe.each(inits)('$description', ({ description, createWallets }) => {
 
     const allowance = await queryClient.cosmos.feegrant.v1beta1.allowance({
       granter: t1Addr,
-      grantee: t2Addr
+      grantee: t2Addr,
     });
     expect(allowance.allowance.granter).toEqual(t1Addr);
     expect(allowance.allowance.grantee).toEqual(t2Addr);

--- a/starship/__tests__/group.test.ts
+++ b/starship/__tests__/group.test.ts
@@ -1,48 +1,52 @@
-import { OfflineSigner } from '@cosmjs/proto-signing';
-import { ConfigContext, generateMnemonic, useRegistry } from 'starshipjs';
+import { OfflineSigner } from "@cosmjs/proto-signing";
+import { ConfigContext, generateMnemonic, useRegistry } from "starshipjs";
 import {
   checkPoaAdminIs,
   createAminoWallet,
   createProtoWallet,
   initChain,
-  POA_GROUP_ADDRESS, submitVoteExecGroupProposal
-} from '../src/test_helper';
-import { assertIsDeliverTxSuccess } from '@cosmjs/stargate';
-import { MessageComposer as GroupMsgComposer } from '../../src/codegen/cosmos/group/v1/tx.registry';
-import { Any } from '../../src/codegen/google/protobuf/any';
-import { ThresholdDecisionPolicy } from '../../src/codegen/cosmos/group/v1/types';
-import { Duration } from '../../src/codegen/google/protobuf/duration';
-import { createRPCQueryClient } from '../../src/codegen/cosmos/rpc.query';
-import path from 'path';
-import { getSigningCosmosClient } from '../../src';
+  POA_GROUP_ADDRESS,
+  submitVoteExecGroupProposal,
+} from "../src/test_helper";
+import { assertIsDeliverTxSuccess } from "@cosmjs/stargate";
+import { MessageComposer as GroupMsgComposer } from "../../src/codegen/cosmos/group/v1/tx.registry";
+import { Any } from "../../src/codegen/google/protobuf/any";
+import { ThresholdDecisionPolicy } from "../../src/codegen/cosmos/group/v1/types";
+import { Duration } from "../../src/codegen/google/protobuf/duration";
+import { createRPCQueryClient } from "../../src/codegen/cosmos/rpc.query";
+import path from "path";
+import { getSigningCosmosClient } from "../../src";
 import {
   MsgUpdateGroupMembers,
   MsgUpdateGroupMetadata,
   MsgUpdateGroupPolicyDecisionPolicy,
   MsgUpdateGroupPolicyDecisionPolicyEncoded,
-  MsgUpdateGroupPolicyMetadata
-} from '../../src/codegen/cosmos/group/v1/tx';
-import { MsgSend } from '../../src/codegen/cosmos/bank/v1beta1/tx';
-import { MsgGrantAllowance } from '../../src/codegen/cosmos/feegrant/v1beta1/tx';
-import { AllowedMsgAllowance, BasicAllowance } from '../../src/codegen/cosmos/feegrant/v1beta1/feegrant';
+  MsgUpdateGroupPolicyMetadata,
+} from "../../src/codegen/cosmos/group/v1/tx";
+import { MsgSend } from "../../src/codegen/cosmos/bank/v1beta1/tx";
+import { MsgGrantAllowance } from "../../src/codegen/cosmos/feegrant/v1beta1/tx";
+import {
+  AllowedMsgAllowance,
+  BasicAllowance,
+} from "../../src/codegen/cosmos/feegrant/v1beta1/feegrant";
 
-BigInt.prototype['toJSON'] = function() {
+BigInt.prototype["toJSON"] = function () {
   return this.toString();
 };
 
 const inits = [
   {
-    description: 'group-module (proto-signing)',
-    createWallets: createProtoWallet
+    description: "group-module (proto-signing)",
+    createWallets: createProtoWallet,
   },
   {
-    description: 'group-module (amino-signing)',
-    createWallets: createAminoWallet
-  }
+    description: "group-module (amino-signing)",
+    createWallets: createAminoWallet,
+  },
 ];
 
 // Test Group module endpoints with both proto and amino signing.
-describe.each(inits)('$description', ({ description, createWallets }) => {
+describe.each(inits)("$description", ({ description, createWallets }) => {
   let test1Wallet: OfflineSigner,
     test2Wallet: OfflineSigner,
     t1Addr: string,
@@ -50,26 +54,26 @@ describe.each(inits)('$description', ({ description, createWallets }) => {
     rpcEndpoint: string,
     fee: { amount: { denom: string; amount: string }[]; gas: string };
 
-  const denom = 'umfx';
+  const denom = "umfx";
 
   beforeAll(async () => {
     const configFile = path.join(
       __dirname,
-      '..',
-      'configs',
-      'config.group.local.yaml'
+      "..",
+      "configs",
+      "config.group.local.yaml"
     );
     ConfigContext.setConfigFile(configFile);
     ConfigContext.setRegistry(await useRegistry(configFile));
 
-    const chainData = await initChain('manifest-ledger-beta');
+    const chainData = await initChain("manifest-ledger-beta");
     rpcEndpoint = chainData.rpcEndpoint;
 
     await checkPoaAdminIs(rpcEndpoint, POA_GROUP_ADDRESS);
 
     test1Wallet = await createWallets(generateMnemonic(), chainData.prefix);
     test2Wallet = await createWallets(generateMnemonic(), chainData.prefix);
-    fee = { amount: [{ denom, amount: '100000' }], gas: '550000' };
+    fee = { amount: [{ denom, amount: "100000" }], gas: "550000" };
 
     t1Addr = (await test1Wallet.getAccounts())[0].address;
     t2Addr = (await test2Wallet.getAccounts())[0].address;
@@ -78,42 +82,42 @@ describe.each(inits)('$description', ({ description, createWallets }) => {
     await chainData.creditFromFaucet(t2Addr, denom);
   });
 
-  test('create group', async () => {
+  test("create group", async () => {
     const client = await getSigningCosmosClient({
       rpcEndpoint,
-      signer: test1Wallet
+      signer: test1Wallet,
     });
     const queryClient = await createRPCQueryClient({ rpcEndpoint });
 
     const msg = GroupMsgComposer.fromPartial.createGroupWithPolicy({
       admin: t1Addr,
       members: [
-        { address: t1Addr, weight: '1', metadata: 'test member 1' },
-        { address: t2Addr, weight: '1', metadata: 'test member 2' }
+        { address: t1Addr, weight: "1", metadata: "test member 1" },
+        { address: t2Addr, weight: "1", metadata: "test member 2" },
       ],
-      groupMetadata: 'test group - ' + description,
-      groupPolicyMetadata: 'test group policy - ' + description,
+      groupMetadata: "test group - " + description,
+      groupPolicyMetadata: "test group policy - " + description,
       groupPolicyAsAdmin: true,
       decisionPolicy: ThresholdDecisionPolicy.toProtoMsg({
-        threshold: '1',
+        threshold: "1",
         windows: {
           votingPeriod: Duration.fromPartial({ seconds: 10n }),
-          minExecutionPeriod: Duration.fromPartial({ seconds: 0n })
-        }
-      })
+          minExecutionPeriod: Duration.fromPartial({ seconds: 0n }),
+        },
+      }),
     });
 
     const result = await client.signAndBroadcast(
       t1Addr,
       [msg],
       fee,
-      'create group test - ' + description
+      "create group test - " + description
     );
     assertIsDeliverTxSuccess(result);
     expect(result.code).toEqual(0);
 
     const groups = await queryClient.cosmos.group.v1.groupsByMember({
-      address: t1Addr
+      address: t1Addr,
     });
     expect(groups.groups.length).toEqual(1);
 
@@ -121,46 +125,74 @@ describe.each(inits)('$description', ({ description, createWallets }) => {
     let sendResult = await client.sendTokens(
       t1Addr,
       groups.groups[0].admin,
-      [{ denom, amount: '10000000' }],
+      [{ denom, amount: "10000000" }],
       fee
     );
     assertIsDeliverTxSuccess(sendResult);
     expect(sendResult.code).toEqual(0);
   });
 
-  describe('group proposals', () => {
-    test('send', async () => {
+  describe("group proposals", () => {
+    test("send", async () => {
       const queryClient = await createRPCQueryClient({ rpcEndpoint });
       const client = await getSigningCosmosClient({
         rpcEndpoint,
-        signer: test1Wallet
+        signer: test1Wallet,
       });
 
       const group = await getGroupByMember(t1Addr);
 
-      const t1AddrBeforeBalance = await queryClient.cosmos.bank.v1beta1.balance({ address: t1Addr, denom: denom });
-      const groupBeforeBalance = await queryClient.cosmos.bank.v1beta1.balance({ address: group.admin, denom: denom });
+      const t1AddrBeforeBalance = await queryClient.cosmos.bank.v1beta1.balance(
+        { address: t1Addr, denom: denom }
+      );
+      const groupBeforeBalance = await queryClient.cosmos.bank.v1beta1.balance({
+        address: group.admin,
+        denom: denom,
+      });
 
       const send: MsgSend = {
         fromAddress: group.admin,
         toAddress: t1Addr,
-        amount: [{ denom, amount: '1000' }]
+        amount: [{ denom, amount: "1000" }],
       };
       const proposal = Any.fromPartial(MsgSend.toProtoMsg(send));
-      await submitVoteExecGroupProposal(t1Addr, group.admin, client, 'send proposal', 'send 1000 tokens to myself', [t1Addr], [proposal], fee);
+      await submitVoteExecGroupProposal(
+        t1Addr,
+        group.admin,
+        client,
+        "send proposal",
+        "send 1000 tokens to myself",
+        [t1Addr],
+        [proposal],
+        fee
+      );
 
-      const t1AddrAfterBalance = await queryClient.cosmos.bank.v1beta1.balance({ address: t1Addr, denom: denom });
-      const groupAfterBalance = await queryClient.cosmos.bank.v1beta1.balance({ address: group.admin, denom: denom });
+      const t1AddrAfterBalance = await queryClient.cosmos.bank.v1beta1.balance({
+        address: t1Addr,
+        denom: denom,
+      });
+      const groupAfterBalance = await queryClient.cosmos.bank.v1beta1.balance({
+        address: group.admin,
+        denom: denom,
+      });
 
-      expect(t1AddrAfterBalance.balance.amount).toEqual((BigInt(t1AddrBeforeBalance.balance.amount) + BigInt('1000') - (BigInt(3) * BigInt(fee.amount[0].amount))).toString());
-      expect(groupAfterBalance.balance.amount).toEqual((BigInt(groupBeforeBalance.balance.amount) - BigInt('1000')).toString());
+      expect(t1AddrAfterBalance.balance.amount).toEqual(
+        (
+          BigInt(t1AddrBeforeBalance.balance.amount) +
+          BigInt("1000") -
+          BigInt(3) * BigInt(fee.amount[0].amount)
+        ).toString()
+      );
+      expect(groupAfterBalance.balance.amount).toEqual(
+        (BigInt(groupBeforeBalance.balance.amount) - BigInt("1000")).toString()
+      );
     }, 30000);
 
-    test('feegrant', async () => {
+    test("feegrant", async () => {
       const queryClient = await createRPCQueryClient({ rpcEndpoint });
       const client = await getSigningCosmosClient({
         rpcEndpoint,
-        signer: test1Wallet
+        signer: test1Wallet,
       });
 
       const group = await getGroupByMember(t1Addr);
@@ -169,51 +201,74 @@ describe.each(inits)('$description', ({ description, createWallets }) => {
         grantee: t1Addr,
         allowance: AllowedMsgAllowance.fromPartial({
           allowance: BasicAllowance.fromPartial({
-            spendLimit: [{ denom, amount: '1000' }],
-            expiration: null
+            spendLimit: [{ denom, amount: "1000" }],
+            expiration: null,
           }),
-          allowedMessages: ['/cosmos.bank.v1beta1.MsgSend']
-        })
+          allowedMessages: ["/cosmos.bank.v1beta1.MsgSend"],
+        }),
       });
 
       const proposal = Any.fromPartial(MsgGrantAllowance.toProtoMsg(feegrant));
-      await submitVoteExecGroupProposal(t1Addr, group.admin, client, 'feegrant proposal', 'feegrant fee authorization', [t1Addr], [proposal], fee);
+      await submitVoteExecGroupProposal(
+        t1Addr,
+        group.admin,
+        client,
+        "feegrant proposal",
+        "feegrant fee authorization",
+        [t1Addr],
+        [proposal],
+        fee
+      );
 
-      const allowance = await queryClient.cosmos.feegrant.v1beta1.allowancesByGranter({ granter: group.admin });
+      const allowance =
+        await queryClient.cosmos.feegrant.v1beta1.allowancesByGranter({
+          granter: group.admin,
+        });
       expect(allowance.allowances.length).toEqual(1);
       expect(allowance.allowances[0].granter).toEqual(feegrant.granter);
       expect(allowance.allowances[0].grantee).toEqual(feegrant.grantee);
     }, 30000);
 
-    test('update group metadata', async () => {
+    test("update group metadata", async () => {
       const queryClient = await createRPCQueryClient({ rpcEndpoint });
       const client = await getSigningCosmosClient({
         rpcEndpoint,
-        signer: test1Wallet
+        signer: test1Wallet,
       });
       const group = await getGroupByMember(t1Addr);
 
       const newMetadata: MsgUpdateGroupMetadata = {
         admin: group.admin,
         groupId: group.id,
-        metadata: 'new metadata'
+        metadata: "new metadata",
       };
       const proposal = Any.fromPartial(
         MsgUpdateGroupMetadata.toProtoMsg(newMetadata)
       );
 
-      await submitVoteExecGroupProposal(t1Addr, group.admin, client, 'update group metadata', 'update the group metadata with new value', [t1Addr], [proposal], fee);
+      await submitVoteExecGroupProposal(
+        t1Addr,
+        group.admin,
+        client,
+        "update group metadata",
+        "update the group metadata with new value",
+        [t1Addr],
+        [proposal],
+        fee
+      );
 
-      queryClient.cosmos.group.v1.groupInfo({ groupId: group.id }).then((groupInfo) => {
-        expect(groupInfo.info.metadata).toEqual(newMetadata.metadata);
-      });
+      queryClient.cosmos.group.v1
+        .groupInfo({ groupId: group.id })
+        .then((groupInfo) => {
+          expect(groupInfo.info.metadata).toEqual(newMetadata.metadata);
+        });
     }, 30000);
 
-    test('remove group members', async () => {
+    test("remove group members", async () => {
       const queryClient = await createRPCQueryClient({ rpcEndpoint });
       const client = await getSigningCosmosClient({
         rpcEndpoint,
-        signer: test1Wallet
+        signer: test1Wallet,
       });
       const group = await getGroupByMember(t1Addr);
       const update: MsgUpdateGroupMembers = {
@@ -222,25 +277,36 @@ describe.each(inits)('$description', ({ description, createWallets }) => {
         memberUpdates: [
           {
             address: t2Addr,
-            weight: '0',
-            metadata: 'user 2'
-          }
-        ]
+            weight: "0",
+            metadata: "user 2",
+          },
+        ],
       };
       const proposal = Any.fromPartial(
         MsgUpdateGroupMembers.toProtoMsg(update)
       );
-      await submitVoteExecGroupProposal(t1Addr, group.admin, client, 'remove group members', 'remove the group members t2Addr', [t1Addr], [proposal], fee);
+      await submitVoteExecGroupProposal(
+        t1Addr,
+        group.admin,
+        client,
+        "remove group members",
+        "remove the group members t2Addr",
+        [t1Addr],
+        [proposal],
+        fee
+      );
 
-      queryClient.cosmos.group.v1.groupsByMember({ address: t2Addr }).then((groups) => {
-        expect(groups.groups.length).toEqual(0);
-      });
+      queryClient.cosmos.group.v1
+        .groupsByMember({ address: t2Addr })
+        .then((groups) => {
+          expect(groups.groups.length).toEqual(0);
+        });
     }, 30000);
 
-    test('add group member', async () => {
+    test("add group member", async () => {
       const client = await getSigningCosmosClient({
         rpcEndpoint,
-        signer: test1Wallet
+        signer: test1Wallet,
       });
       const group = await getGroupByMember(t1Addr);
       const update: MsgUpdateGroupMembers = {
@@ -249,73 +315,100 @@ describe.each(inits)('$description', ({ description, createWallets }) => {
         memberUpdates: [
           {
             address: t2Addr,
-            weight: '1',
-            metadata: 'user 2'
-          }
-        ]
+            weight: "1",
+            metadata: "user 2",
+          },
+        ],
       };
       const proposal = Any.fromPartial(
         MsgUpdateGroupMembers.toProtoMsg(update)
       );
-      await submitVoteExecGroupProposal(t1Addr, group.admin, client, 'add group members', 'add the group members t2Addr', [t1Addr], [proposal], fee);
+      await submitVoteExecGroupProposal(
+        t1Addr,
+        group.admin,
+        client,
+        "add group members",
+        "add the group members t2Addr",
+        [t1Addr],
+        [proposal],
+        fee
+      );
 
       const groupAfter = await getGroupByMember(t2Addr);
       expect(groupAfter.admin).toEqual(group.admin);
     }, 30000);
 
-    test('update group policy metadata', async () => {
+    test("update group policy metadata", async () => {
       const queryClient = await createRPCQueryClient({ rpcEndpoint });
       const client = await getSigningCosmosClient({
         rpcEndpoint,
-        signer: test1Wallet
+        signer: test1Wallet,
       });
       const group = await getGroupByMember(t1Addr);
 
       const newMetadata: MsgUpdateGroupPolicyMetadata = {
         admin: group.admin,
         groupPolicyAddress: group.admin,
-        metadata: 'new group policy metadata'
+        metadata: "new group policy metadata",
       };
       const proposal = Any.fromPartial(
         MsgUpdateGroupPolicyMetadata.toProtoMsg(newMetadata)
       );
 
-      await submitVoteExecGroupProposal(t1Addr, group.admin, client, 'update group policy metadata', 'update the group policy metadata', [t1Addr], [proposal], fee);
+      await submitVoteExecGroupProposal(
+        t1Addr,
+        group.admin,
+        client,
+        "update group policy metadata",
+        "update the group policy metadata",
+        [t1Addr],
+        [proposal],
+        fee
+      );
 
       const groupPolicyAfter =
         await queryClient.cosmos.group.v1.groupPolicyInfo({
-          address: group.admin
+          address: group.admin,
         });
       expect(groupPolicyAfter.info.metadata).toEqual(newMetadata.metadata);
     }, 30000);
 
-    test('update group policy decision policy', async () => {
+    test("update group policy decision policy", async () => {
       const client = await getSigningCosmosClient({
         rpcEndpoint,
-        signer: test1Wallet
+        signer: test1Wallet,
       });
       const queryClient = await createRPCQueryClient({ rpcEndpoint });
       const group = await getGroupByMember(t1Addr);
 
       const newPolicy = ThresholdDecisionPolicy.fromPartial({
-        threshold: '1',
+        threshold: "1",
         windows: {
           votingPeriod: Duration.fromPartial({ seconds: 15n }),
-          minExecutionPeriod: Duration.fromPartial({ seconds: 0n })
-        }
+          minExecutionPeriod: Duration.fromPartial({ seconds: 0n }),
+        },
       });
       const newPolicyEncoded: MsgUpdateGroupPolicyDecisionPolicyEncoded = {
         admin: group.admin,
         groupPolicyAddress: group.admin,
-        decisionPolicy: ThresholdDecisionPolicy.toProtoMsg(newPolicy)
+        decisionPolicy: ThresholdDecisionPolicy.toProtoMsg(newPolicy),
       };
       const proposal = Any.fromPartial(
         MsgUpdateGroupPolicyDecisionPolicy.toProtoMsg(newPolicyEncoded)
       );
-      await submitVoteExecGroupProposal(t1Addr, group.admin, client, 'update group policy decision policy', 'update the group policy decision policy', [t1Addr], [proposal], fee);
+      await submitVoteExecGroupProposal(
+        t1Addr,
+        group.admin,
+        client,
+        "update group policy decision policy",
+        "update the group policy decision policy",
+        [t1Addr],
+        [proposal],
+        fee
+      );
       const groupPolicyAfter =
         await queryClient.cosmos.group.v1.groupPolicyInfo({
-          address: group.admin
+          address: group.admin,
         });
       expect(groupPolicyAfter.info.decisionPolicy).toEqual(newPolicy);
     }, 30000);
@@ -324,7 +417,7 @@ describe.each(inits)('$description', ({ description, createWallets }) => {
   async function getGroupByMember(address: string) {
     const queryClient = await createRPCQueryClient({ rpcEndpoint });
     const groups = await queryClient.cosmos.group.v1.groupsByMember({
-      address
+      address,
     });
     expect(groups.groups.length).toEqual(1);
     return groups.groups[0];

--- a/starship/__tests__/group.test.ts
+++ b/starship/__tests__/group.test.ts
@@ -29,9 +29,9 @@ import {
   AllowedMsgAllowance,
   BasicAllowance,
 } from "../../src/codegen/cosmos/feegrant/v1beta1/feegrant";
-import { Grant } from '../../src/codegen/cosmos/authz/v1beta1/authz';
-import { SendAuthorization } from '../../src/codegen/cosmos/bank/v1beta1/authz';
-import { MsgGrant } from '../../src/codegen/cosmos/authz/v1beta1/tx';
+import { Grant } from "../../src/codegen/cosmos/authz/v1beta1/authz";
+import { SendAuthorization } from "../../src/codegen/cosmos/bank/v1beta1/authz";
+import { MsgGrant } from "../../src/codegen/cosmos/authz/v1beta1/tx";
 
 BigInt.prototype["toJSON"] = function () {
   return this.toString();
@@ -206,9 +206,9 @@ describe.each(inits)("$description", ({ description, createWallets }) => {
           authorization: SendAuthorization.fromPartial({
             spendLimit: [{ denom, amount: "1000" }],
             allowList: [""],
-          })
+          }),
         }),
-      })
+      });
 
       const proposal = Any.fromPartial(MsgGrant.toProtoMsg(grant));
       await submitVoteExecGroupProposal(
@@ -222,10 +222,9 @@ describe.each(inits)("$description", ({ description, createWallets }) => {
         fee
       );
 
-      const allowance =
-        await queryClient.cosmos.authz.v1beta1.granterGrants({
-          granter: group.admin,
-        });
+      const allowance = await queryClient.cosmos.authz.v1beta1.granterGrants({
+        granter: group.admin,
+      });
       expect(allowance.grants.length).toEqual(1);
       expect(allowance.grants[0].granter).toEqual(grant.granter);
       expect(allowance.grants[0].grantee).toEqual(grant.grantee);

--- a/starship/src/index.ts
+++ b/starship/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./utils"
+export * from "./utils";

--- a/starship/src/utils.ts
+++ b/starship/src/utils.ts
@@ -1,17 +1,26 @@
 // @ts-nocheck
 import { ChainInfo } from "@chain-registry/client";
-import { Coin, DirectSecp256k1HdWallet, OfflineSigner } from '@cosmjs/proto-signing';
-import { assertIsDeliverTxSuccess, SigningStargateClient } from '@cosmjs/stargate';
-import BigNumber from 'bignumber.js';
-import { ConfigContext, generateMnemonic, useChain } from 'starshipjs';
+import {
+  Coin,
+  DirectSecp256k1HdWallet,
+  OfflineSigner,
+} from "@cosmjs/proto-signing";
+import {
+  assertIsDeliverTxSuccess,
+  SigningStargateClient,
+} from "@cosmjs/stargate";
+import BigNumber from "bignumber.js";
+import { ConfigContext, generateMnemonic, useChain } from "starshipjs";
 
-import { getSigningIbcClient } from '../../src';
+import { getSigningIbcClient } from "../../src";
 
 export const calcShareOutAmount = (poolInfo, coinsNeeded) => {
   return poolInfo.poolAssets
     .map(({ token }, i) => {
       const tokenInAmount = new BigNumber(coinsNeeded[i].amount);
-      const totalShare = new BigNumber(poolInfo.totalShares.amount).shiftedBy(-18);
+      const totalShare = new BigNumber(poolInfo.totalShares.amount).shiftedBy(
+        -18
+      );
       const poolAssetAmount = new BigNumber(token.amount);
 
       return tokenInAmount
@@ -27,25 +36,42 @@ export const calcShareOutAmount = (poolInfo, coinsNeeded) => {
 export const waitUntil = (date, timeout = 90000) => {
   const delay = date.getTime() - Date.now();
   if (delay > timeout) {
-    throw new Error('Timeout to wait until date');
+    throw new Error("Timeout to wait until date");
   }
-  return new Promise(resolve => setTimeout(resolve, delay + 3000));
+  return new Promise((resolve) => setTimeout(resolve, delay + 3000));
 };
 
-export const transferIbcTokens = async (fromChain: string, toChain: string, toAddress: string, amount: string) => {
+export const transferIbcTokens = async (
+  fromChain: string,
+  toChain: string,
+  toAddress: string,
+  amount: string
+) => {
   const fromChainData: any = useChain(fromChain);
   const toChainData: any = useChain(toChain);
   const ibcInfo = findIbcInfo(fromChainData.chainInfo, toChainData.chainInfo);
 
-  const wallet = await createTempWallet(fromChainData.chainInfo.chain.bech32_prefix);
+  const wallet = await createTempWallet(
+    fromChainData.chainInfo.chain.bech32_prefix
+  );
   const fromAddress = (await wallet.getAccounts())[0].address;
 
   await fromChainData.creditFromFaucet(fromAddress);
 
-  const fromClient = await setupIbcClient(await fromChainData.getRpcEndpoint(), wallet);
+  const fromClient = await setupIbcClient(
+    await fromChainData.getRpcEndpoint(),
+    wallet
+  );
   const token = { denom: (await fromChainData.getCoin()).base, amount };
 
-  const resp = await sendIbcTokens(fromClient, fromAddress, toAddress, token, ibcInfo, amount);
+  const resp = await sendIbcTokens(
+    fromClient,
+    fromAddress,
+    toAddress,
+    token,
+    ibcInfo,
+    amount
+  );
 
   assertIsDeliverTxSuccess(resp);
   return token;
@@ -55,25 +81,51 @@ const findIbcInfo = (chainInfo: ChainInfo, toChainInfo: ChainInfo) => {
   const registry = ConfigContext.registry;
   const ibcInfos = registry!.getChainIbcData(chainInfo.chain.chain_name);
   const found = ibcInfos.find(
-    i => i.chain_1.chain_name === chainInfo.chain.chain_name &&
+    (i) =>
+      i.chain_1.chain_name === chainInfo.chain.chain_name &&
       i.chain_2.chain_name === toChainInfo.chain.chain_name
   );
-  if (!found) throw new Error('Cannot find IBC info');
+  if (!found) throw new Error("Cannot find IBC info");
   return found;
 };
 
 const createTempWallet = async (bech32Prefix: string) => {
-  return DirectSecp256k1HdWallet.fromMnemonic(generateMnemonic(), { prefix: bech32Prefix });
+  return DirectSecp256k1HdWallet.fromMnemonic(generateMnemonic(), {
+    prefix: bech32Prefix,
+  });
 };
 
-const setupIbcClient = async (rpcEndpoint: string, wallet: OfflineSigner): Promise<SigningStargateClient> => {
+const setupIbcClient = async (
+  rpcEndpoint: string,
+  wallet: OfflineSigner
+): Promise<SigningStargateClient> => {
   return getSigningIbcClient({ rpcEndpoint, signer: wallet });
 };
 
-const sendIbcTokens = async (client: SigningStargateClient, fromAddress: string, toAddress: string, token: Coin, ibcInfo: any, _amount) => {
-  const { port_id: sourcePort, channel_id: sourceChannel } = ibcInfo.channels[0].chain_1;
+const sendIbcTokens = async (
+  client: SigningStargateClient,
+  fromAddress: string,
+  toAddress: string,
+  token: Coin,
+  ibcInfo: any,
+  _amount
+) => {
+  const { port_id: sourcePort, channel_id: sourceChannel } =
+    ibcInfo.channels[0].chain_1;
   const timeoutTime = Math.floor(Date.now() / 1000) + 300; // 5 minutes
-  const fee = { amount: [{ denom: token.denom, amount: '100000' }], gas: '550000' };
+  const fee = {
+    amount: [{ denom: token.denom, amount: "100000" }],
+    gas: "550000",
+  };
 
-  return client.sendIbcTokens(fromAddress, toAddress, token, sourcePort, sourceChannel, undefined, timeoutTime, fee);
+  return client.sendIbcTokens(
+    fromAddress,
+    toAddress,
+    token,
+    sourcePort,
+    sourceChannel,
+    undefined,
+    timeoutTime,
+    fee
+  );
 };


### PR DESCRIPTION
This PR adds tests for the AuthZ and Feegrant module.

AuthZ quick: 

The `allowList` cannot be `[]`; it MUST to contain a value. 

The problem is that the message being signed will contain this empty field while the message decoded by the server will not contain it.

E.g., 
Client
```json
{
  "type": "cosmos-sdk/MsgGrant",
  "value": {
    "granter": "manifest19lselfrn286cnjahfpfnnejnhqmv2ndyxs7uze",
    "grantee": "manifest1tn3rcpt3d6mjy6z99szurnyju44dah4npu5e5f",
    "grant": {
      "authorization": {
        "type": "cosmos-sdk/SendAuthorization",
        "value": {
          "spend_limit": [
            {
              "denom": "umfx",
              "amount": "10000"
            }
          ],
          "allow_list": []
        }
      }
    }
  }
}
```

Server
```json
{
  "type": "cosmos-sdk/MsgGrant",
  "value": {
    "grant": {
      "authorization": {
        "type": "cosmos-sdk/SendAuthorization",
        "value": {
          "spend_limit": [
            {
              "amount": "10000",
              "denom": "umfx"
            }
          ]
        }
      }
    },
    "grantee": "manifest1tn3rcpt3d6mjy6z99szurnyju44dah4npu5e5f",
    "granter": "manifest19lselfrn286cnjahfpfnnejnhqmv2ndyxs7uze"
  }
}
```

Notice the missing empty list on the server. Obviously, the signature won't match because of this.

Other than that, it works. 